### PR TITLE
replace Object.assign in favor of deepmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ When accepting it will load guarded scripts in meta tags.
 
 ## Browser support
 
-This library supports the latest 2 versions of all modern browsers. But support can be extended by using some polyfills.
-- IE11+ support by adding Object.assign polyfill
-- IE10+ support by adding element.dataset polyfill 
+This library supports the latest 2 versions of all modern browsers + IE11. But support can be extended by using some polyfills.
+- IE10 support by adding element.dataset polyfill 
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,6 +2099,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+      "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "webpack-cli": "^2.0.12"
   },
   "dependencies": {
+    "deepmerge": "^2.1.0",
     "js-cookie": "^2.2.0"
   },
   "homepage": "https://github.com/freshheads/cookie-guard#readme",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
 import Cookie from 'js-cookie';
+import merge from 'deepmerge';
 
 class FHCookieGuard {
     constructor(selector = '.js-cookie-alert', options = {}) {
@@ -26,7 +27,7 @@ class FHCookieGuard {
             }
         };
 
-        this.options = Object.assign(this.options, options, this.cookieAlert.dataset);
+        this.options = merge.all([this.options, options, this.cookieAlert.dataset]);
 
         this._onAcceptCookiesClick = this._onAcceptCookiesClick.bind(this);
         this._onRefuseCookiesClick = this._onRefuseCookiesClick.bind(this);


### PR DESCRIPTION
Solves #5 
This does add 15kb to the production build, something to be aware of since this is otherwise a very lightweight library. An alternative could be to flatten the options so Object.assign is still possible.. what are your thoughts?

