### PR TITLE
Fix label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const CookieGuardProps = {
     acceptAllLabel: 'Alle cookies accepteren',
     saveLabel: 'Opslaan',
     requiredLabel: 'Noodzakelijke cookies'.
-    functionalLabel: 'Noodzakelijke cookies',
+    functionalLabel: 'Functionele cookies',
     analyticsLabel: 'Analytische cookies',
     marketingLabel: 'Marketing cookies',
 }


### PR DESCRIPTION
The label for _functional_ cookies still reads `Noodzakelijke cookies` at the moment. I suppose this should be `Functionele cookies` 😉